### PR TITLE
Upgrade py 3 11 ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM public.ecr.aws/lambda/python:3.8
-#FROM continuumio/miniconda3:4.8.2
+# using arm64 as building on M1 Mac
+FROM public.ecr.aws/lambda/python:3.11-arm64
 
 # Install the function's dependencies using file requirements.txt
 # from your project folder.
@@ -15,9 +15,13 @@ ENV CONFIG_PATH=/config/configuration.txt
 
 # Copy function code
 COPY app.py ${LAMBDA_TASK_ROOT}
-# TODO: fix this here and in where code looks for this file
 COPY config/configuration.txt ${CONFIG_PATH}
 COPY wid_tools.py ${LAMBDA_TASK_ROOT}
+
+# When testing in local docker container, mount aws config to test push to s3
+# ENV AWS_CONFIG_FILE=/config/aws/config
+# COPY config/aws_config.txt /config/aws/config
+
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "app.handler" ]

--- a/README.md
+++ b/README.md
@@ -20,26 +20,43 @@ The WIDDoughMaker fetches assets (aka pitches) and their respective price histor
 [Click me](https://www.whiskyinvestdirect.com/tullibardine/2015/Q4/BBF/chart.do)
 
 # Building and Testing Docker Image for Lambda
-1. From repo root, run
-`docker build . -t widdoughmaker`
+1. Populate `config/configuration.txt` with Whiskey credentials
 
-2. Run docker image
-`docker run -it --rm -p 9000:8080 widdoughmaker`
+2. Populate `config/aws_config.txt` with AWS IAM creds
 
-3. Curl port running images
+3. Temporarily uncomment lines in `Dockerfile` to mount AWS credentials. This isn't necessary in production as
+command will be run in AWS lambda where credentials are part of the sesion
+```Dockerfile
+# ENV AWS_CONFIG_FILE=/config/aws/config
+# COPY config/aws_config.txt /config/aws/config
+```
+
+4. From repo root, run
+`docker build . -t widdoughmaker:YOUR_TAG`
+
+5. Run docker image
+`docker run -it --rm -p 9000:8080 widdoughmaker:YOUR_TAG`
+
+6. Curl port running images
 `curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'`
 
-4. Authenticate Docker to AWS ECR
-`aws ecr get-login-password --region us-east-1 --profile fil_personal | docker login --username AWS --password-stdin 400419513456.dkr.ecr.us-east-1.amazonaws.com`
+7. Comment out lines in Dockerfile from item 3
 
-5. Create ECR Repository if it doesn't already exist. Follow instructions for configuring ECR repository for Lambda [here](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-images.html#configuration-images-update).
+8. Authenticate Docker to AWS ECR.
+**Note:** Assumes your `~/.aws/config` is properly set to access your aws environment 
+
+`aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 400419513456.dkr.ecr.us-east-1.amazonaws.com`
+
+9. Create ECR Repository if it doesn't already exist. Follow instructions for configuring ECR repository for Lambda [here](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-images.html#configuration-images-update).
 `aws ecr create-repository --repository-name widdoughmaker --image-scanning-configuration scanOnPush=true --image-tag-mutability MUTABLE --profile fil_personal`
 
-6. Tag Docker image to match repository name
-`docker tag  widdoughmaker:latest 400419513456.dkr.ecr.us-east-1.amazonaws.com/widdoughmaker:latest`
+10. Tag Docker image to match repository name
+`docker tag  widdoughmaker:YOUR_TAG 400419513456.dkr.ecr.us-east-1.amazonaws.com/widdoughmaker:YOUR_TAG`
 
-7. Push Docker Image to ECR
-`docker push 400419513456.dkr.ecr.us-east-1.amazonaws.com/widdoughmaker:latest`
+11. Push Docker Image to ECR
+`docker push 400419513456.dkr.ecr.us-east-1.amazonaws.com/widdoughmaker:YOUR_TAG`
+12. In the Lambda console, choose to deploy a new image. Make sure to specify the correct architecture for your image
+either arm64 or x86
 
 # Configuring an AWS Glue Crawler
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
-pandas==1.1.2
-numpy==1.19.1
+pandas<2.0
+numpy
 boto3==1.14.63
 s3fs
 requests


### PR DESCRIPTION
AWS is ending support for the Python 3.7 image. Upgrade to Python 3.11, changing pandas and numpy versions to meet requirements. Additionally had to specify an ARM64 image because I'm developing, building and pushing from an M1 mac. Couple quality-of-life changes to support local development re: credentials for whiskey invest direct and AWS stuff that I was rusty with.