### PR TITLE
Process raw data wide to long format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # TODOs
 - 
 - want to refactor so we can have a lambda take an s3 path and process it
-  - `etl/stack_records_wide_to_long.py` written to run in a single python sesh. Want to
-  take the atomic processing function and make it its own lambda which takes an s3 path as 
-  input. Ideally want the same Dockerfile to have multiple functions defined in app.py. Then the lambda
-  can specify its own CMD. Will also need to modify existing lambda that scrapes data
+  - Current bug: Read-only file system: 'stage.csv.C1C7B3d0'
+  - Log to current bug: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fwid-Docker-test/log-events/2023%2F10%2F08%2F[%24LATEST]5dcad3a09541448ca486c12c9856fe68?start=PT1H
+  - looks like need to download the file to memory instead of disk. nbd
 - todo: whether to trigger a processing lambda upon a new object landing in s3?
 
 # Goals:
@@ -24,6 +23,24 @@ The WIDDoughMaker fetches assets (aka pitches) and their respective price histor
 4. Configure AWS Glue crawler to traverse the `s3://wid-prices-processed` bucket, making the contents queryable on-demand. See configuration in section below
 
 5. Add partitions? 
+
+# Seting up Local Environment with AWS Creds
+
+1. Create a file in the following format
+```
+[default]
+aws_access_key_id = string
+aws_secret_access_key = string
+region = us-east-1
+output = json
+```
+
+2. Specify the path to that file as the environment variable `AWS_CONFIG_FILE`
+```bash
+export AWS_CONFIG_FILE=string
+```
+
+# Transform Records From Wide to Long
 
 # Sample price chart
 [Click me](https://www.whiskyinvestdirect.com/tullibardine/2015/Q4/BBF/chart.do)

--- a/etl/stack_records_wide_to_long.py
+++ b/etl/stack_records_wide_to_long.py
@@ -95,6 +95,10 @@ def prices_wide_to_long(download_bucket, key, upload_bucket, s3_client):
 
 def crawl_and_process_bucket(download_bucket, upload_bucket, prefix=''):
     """_summary_
+    Initialize an s3 client and list objects in download_bucket matching a prefix. Check whether to process
+    that file by seeing whether there's an accompanying one in the upload_bucket.
+
+    If Exception is hit, create a local cookie file to denote the problematic record for future resolution
     """
     s3_client = boto3.client('s3')
     paginator = s3_client.get_paginator('list_objects_v2')

--- a/etl/stack_records_wide_to_long.py
+++ b/etl/stack_records_wide_to_long.py
@@ -1,37 +1,26 @@
-'''
-Processing script to take a dataframe where ordinal buy/sell orders are added as columns and transform to case where
-they are represented as rows. Check s3 to see if a processed version of the timestamped file exists before processing it
+"""
+TODO: docstring for file
 
-Pseudocode:
-- get all files from raw bucket
-- for each file:
-    - check if one exists with same key in processed bucket
-    - if not: process and write
-    - if so: skip
-
-'''
+"""
 import boto3
 import io
+import pandas as pd
+from io import BytesIO, StringIO
 import os
-import csv
-from pathlib import Path
-import pandas as pd
-import pandas as pd
 from pathlib import Path
 
-raw_bucket = 'wid-prices'
-bucket = 'wid-prices-processed'
-s3_client = boto3.client('s3')
+RAW_BUCKET = 'wid-prices'
+PROCESSED_BUCKET = 'wid-prices-processed'
 
 
-def stack_df(df, key):
-    '''
+def wide_to_long(df, key):
+    """
     Given a wide dataframe for a single whisky and columns for each buy/sell order, transform the columns into rows
     where the resulting dataframe is long with one row per buy/sell order
     :param df: wide dataframe
     :param key: s3 file key
     :return: long dataframe
-    '''
+    """
     year, month, day, fname = key.split('/')
     hours = fname.split('.')[0][-6:-4]
     minutes = fname.split('.')[0][-4:-2]
@@ -40,9 +29,15 @@ def stack_df(df, key):
     dt_str = f'{year}/{month}/{day} {hours}:{minutes}:{seconds}'
 
     gcols = ['barrel_type', 'category', 'currency', 'distillery', 'year', 'security_id', 'qtr']
-    tmp = df.set_index(gcols).stack().reset_index()
+    tmp = df.drop(['Unnamed: 0'], axis=1).set_index(gcols).stack().reset_index()
     tmp.columns = gcols + ['value_field', 'value']
-    tmp = tmp.query('value_field!="index"').copy()
+    # TODO: how to filter and alert if weird values creep in..
+    # IDEA: filter out null column name first then assert all cols start with po or so
+    # Current values seem to begin with po_ and so_
+    # tmp = tmp.query('value_field!="index"').copy()
+    tmp = tmp[tmp['value_field'].str.startswith('po_') |
+              tmp['value_field'].str.startswith('so_')
+              ].copy()
     tmp['happened_at'] = dt_str
 
     tmp['action_type'] = tmp['value_field'].apply(lambda x: x.split('_')[0])
@@ -52,26 +47,14 @@ def stack_df(df, key):
     return tmp
 
 
-def fix_and_upload(staging_fname, upload_bucket, upload_key):
-    '''
+def upload_df_to_s3(df, upload_bucket, upload_key, s3_client):
+    """
     Read file from disk, write data to s3 bucket
-    :param staging_fname: local file to be used as staging file
+    :param df: dataframe of wide whiskey prices, one col for each buy/sell offer and qty
     :param upload_bucket: bucket to upload file to
     :param upload_key: file name to give to uploaded file
     :return: None
-    '''
-    buffer_to_read = io.BytesIO()
-    with open(staging_fname, 'r') as inFile:
-        r = csv.reader(inFile)
-        # copy the rest
-        for i, row in enumerate(r):
-            if i == 0:
-                row[0] = 'index'
-            buffer_to_read.write((','.join(row) + '\n').encode('utf-8'))
-    buffer_to_read.seek(0)
-    # easier to manipulate as df
-    df = pd.read_csv(buffer_to_read)
-    df = stack_df(df, upload_key)
+    """
     buffer_to_upload = io.StringIO()
     df.to_csv(buffer_to_upload, index=False)
     buffer_to_upload.seek(0)
@@ -79,7 +62,21 @@ def fix_and_upload(staging_fname, upload_bucket, upload_key):
     return None
 
 
-def prices_wide_to_long(download_bucket, key, upload_bucket, staging_fname='stage.csv'):
+def read_wide_df_from_s3(download_bucket, key, s3_client):
+    """
+    Download bytes object from s3 into in-memory buffer. Read into dataframe and return
+    :param download_bucket: s3 bucket to download from
+    :param key: path in bucket where file is downloaded from/written to
+    :return: Dataframe of whiskey prices
+    """
+    bio = BytesIO()
+
+    s3_client.download_fileobj(Bucket=download_bucket, Key=key, Fileobj=bio)
+    bio.seek(0)
+    return pd.read_csv(StringIO(bio.read().decode('utf-8')))
+
+
+def prices_wide_to_long(download_bucket, key, upload_bucket, s3_client):
     """
     Pull a wide file from download_bucket with path key, transform it to long file and write to another bucket
     using name key as path
@@ -89,9 +86,49 @@ def prices_wide_to_long(download_bucket, key, upload_bucket, staging_fname='stag
     :param staging_fname: name of file on local disk
     :return:
     """
-    s3_client.download_file(Bucket=download_bucket, Key=key, Filename=staging_fname)
-    fix_and_upload(staging_fname=staging_fname, upload_bucket=upload_bucket, upload_key=key)
-    return
+
+    wide_df = read_wide_df_from_s3(download_bucket=download_bucket, key=key, s3_client=s3_client)
+    long_df = wide_to_long(wide_df, key)
+    upload_df_to_s3(df=long_df, upload_bucket=upload_bucket, upload_key=key, s3_client=s3_client)
+    return long_df
 
 
+def crawl_and_process_bucket(download_bucket, upload_bucket, prefix=''):
+    """_summary_
+    """
+    s3_client = boto3.client('s3')
+    paginator = s3_client.get_paginator('list_objects_v2')
+    page_iterator = paginator.paginate(
+        Bucket=download_bucket,
+        Prefix=prefix
+        )
+    files_to_skip = []
+    for page in page_iterator:
+        for obj in page['Contents']:
+            processed_files_pref = s3_client.list_objects(Bucket=upload_bucket, Prefix=obj['Key'])
+            if len(processed_files_pref.get('Contents', [])) == 0:
+                try:
+                    prices_wide_to_long(
+                        download_bucket=download_bucket,
+                        key=obj['Key'],
+                        upload_bucket=upload_bucket,
+                        s3_client=s3_client
+                        )
+                except Exception as e:
+                    print(f"Error processing {obj['Key']}. Error: {str(e)}")
+                    Path(f"errors_processing/{obj['Key']}").mkdir(parents=True, exist_ok=True)
+                    os.system(f"touch errors_processing/{obj['Key']}.txt")
+            else:
+                files_to_skip.append(processed_files_pref['Contents'][0])
+                #print(f"Skipping {obj['Key']} because processed version already exists")
 
+
+if __name__ == "__main__":
+    # modify prefix as needed YEAR/MONTH/DAY/FILE_NAME
+    days = list(map(lambda x: x.strftime("%Y/%m/%d"), pd.date_range('2024-01-01','2024-03-01', freq='D')))[::7]
+    for day_as_bucket in days:
+        crawl_and_process_bucket(
+            download_bucket=RAW_BUCKET,
+            upload_bucket=PROCESSED_BUCKET,
+            prefix=day_as_bucket
+        )

--- a/etl/stack_records_wide_to_long.py
+++ b/etl/stack_records_wide_to_long.py
@@ -102,7 +102,6 @@ def crawl_and_process_bucket(download_bucket, upload_bucket, prefix=''):
         Bucket=download_bucket,
         Prefix=prefix
         )
-    files_to_skip = []
     for page in page_iterator:
         for obj in page['Contents']:
             processed_files_pref = s3_client.list_objects(Bucket=upload_bucket, Prefix=obj['Key'])
@@ -119,13 +118,12 @@ def crawl_and_process_bucket(download_bucket, upload_bucket, prefix=''):
                     Path(f"errors_processing/{obj['Key']}").mkdir(parents=True, exist_ok=True)
                     os.system(f"touch errors_processing/{obj['Key']}.txt")
             else:
-                files_to_skip.append(processed_files_pref['Contents'][0])
-                #print(f"Skipping {obj['Key']} because processed version already exists")
+                print(f"Skipping {obj['Key']} because processed version already exists")
 
 
 if __name__ == "__main__":
     # modify prefix as needed YEAR/MONTH/DAY/FILE_NAME
-    days = list(map(lambda x: x.strftime("%Y/%m/%d"), pd.date_range('2024-01-01','2024-03-01', freq='D')))[::7]
+    days = list(map(lambda x: x.strftime("%Y/%m/%d"), pd.date_range('2023-01-01','2023-12-31', freq='W-MON')))
     for day_as_bucket in days:
         crawl_and_process_bucket(
             download_bucket=RAW_BUCKET,


### PR DESCRIPTION
# Summary

The file `etl/stack_records_wide_to_long.py` was previously incomplete. It had building block for processing data from wide to long but had not been strung together. This PR does the last 10% to put together an easy script for iterating over the raw data bucket and processing files that don't have a counterpart in the processed data bucket.

# What was changed
- add `__main__` to `etl/stack_records_wide_to_long.py` allowing you to specify a list of dates whose files to process
- `crawl_and_process_bucket()` method to list objects in bucket and determine whether it needs to be processed from wide to long
- modify `README.md` to clarify how to set up local env to access AWS